### PR TITLE
Scan fork releases for PEP 503 index

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,6 +1,12 @@
 name: Update PEP 503 index
 
 on:
+  # Manual trigger
+  workflow_dispatch:
+  # Scheduled: daily at 3 AM UTC (after weekly builds complete)
+  schedule:
+    - cron: '0 3 * * *'
+  # When this repo gets a release (fallback)
   release:
     types: [published]
 
@@ -20,15 +26,7 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Download release assets info
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release list --json tagName > /tmp/releases.json
-          echo "Releases found:"
-          cat /tmp/releases.json
-
-      - name: Generate PEP 503 index
+      - name: Generate PEP 503 index from fork releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/packages.json
+++ b/packages.json
@@ -1,12 +1,12 @@
 {
   "packages": [
-    {"name": "tokenizers", "version": null, "python": "cp313", "source": "huggingface/tokenizers", "lang": "rust", "status": "planned"},
-    {"name": "pydantic-core", "version": null, "python": "cp313", "source": "pydantic/pydantic-core", "lang": "rust", "status": "planned"},
-    {"name": "safetensors", "version": null, "python": "cp313", "source": "huggingface/safetensors", "lang": "rust", "status": "planned"},
-    {"name": "tiktoken", "version": null, "python": "cp313", "source": "openai/tiktoken", "lang": "rust", "status": "planned"},
-    {"name": "blake3", "version": null, "python": "cp313", "source": "BLAKE3-team/BLAKE3", "lang": "rust+c", "status": "planned"},
-    {"name": "sentencepiece", "version": null, "python": "cp313", "source": "google/sentencepiece", "lang": "c++", "status": "planned"},
-    {"name": "pillow", "version": null, "python": "cp313", "source": "python-pillow/Pillow", "lang": "c", "status": "planned"}
+    {"name": "tokenizers", "version": null, "python": "cp313", "source": "huggingface/tokenizers", "fork": "gounthar/tokenizers", "lang": "rust", "status": "planned"},
+    {"name": "pydantic-core", "version": null, "python": "cp313", "source": "pydantic/pydantic-core", "fork": "gounthar/pydantic-core", "lang": "rust", "status": "planned"},
+    {"name": "safetensors", "version": null, "python": "cp313", "source": "huggingface/safetensors", "fork": "gounthar/safetensors", "lang": "rust", "status": "planned"},
+    {"name": "tiktoken", "version": null, "python": "cp313", "source": "openai/tiktoken", "fork": "gounthar/tiktoken", "lang": "rust", "status": "planned"},
+    {"name": "blake3", "version": null, "python": "cp313", "source": "oconnor663/blake3-py", "fork": "gounthar/blake3-py", "lang": "rust+c", "status": "planned"},
+    {"name": "sentencepiece", "version": null, "python": "cp313", "source": "google/sentencepiece", "fork": "gounthar/sentencepiece", "lang": "c++", "status": "planned"},
+    {"name": "pillow", "version": null, "python": "cp313", "source": "python-pillow/Pillow", "fork": "gounthar/Pillow", "lang": "c", "status": "planned"}
   ],
   "build_target": {
     "arch": "riscv64",

--- a/scripts/generate-index.py
+++ b/scripts/generate-index.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Generate a PEP 503 compliant simple package index.
 
-Reads packages.json for the package list and scans wheel files
-(from a local directory or GitHub release assets) to generate
-a static simple/ directory structure suitable for use with
-pip --extra-index-url.
+Reads packages.json for the package list and scans GitHub release
+assets across all fork repositories to generate a static simple/
+directory structure suitable for use with pip --extra-index-url.
 """
 
 import hashlib
@@ -30,7 +29,7 @@ def normalize_name(name: str) -> str:
 
 
 def get_release_assets(repo: str) -> list[dict]:
-    """Fetch release assets from GitHub using gh CLI."""
+    """Fetch release assets from a GitHub repo using gh CLI."""
     try:
         result = subprocess.run(
             ["gh", "release", "list", "--repo", repo, "--json", "tagName"],
@@ -55,6 +54,7 @@ def get_release_assets(repo: str) -> list[dict]:
                     assets.append({
                         "name": asset["name"],
                         "url": asset["url"],
+                        "repo": repo,
                         "tag": tag,
                     })
         except subprocess.CalledProcessError:
@@ -63,15 +63,20 @@ def get_release_assets(repo: str) -> list[dict]:
     return assets
 
 
-def generate_index(wheels_dir: str | None, output_dir: str,
-                   repo: str = "gounthar/riscv64-python-wheels") -> None:
+def generate_index(wheels_dir: str | None, output_dir: str) -> None:
     packages_file = Path(__file__).parent.parent / "packages.json"
     with open(packages_file) as f:
         config = json.load(f)
 
-    package_names = {normalize_name(p["name"]) for p in config["packages"]}
+    # Build mapping: normalized name -> fork repo
+    package_forks: dict[str, str] = {}
+    for p in config["packages"]:
+        norm = normalize_name(p["name"])
+        package_forks[norm] = p.get("fork", "")
 
-    # Collect wheels from local directory or GitHub releases
+    package_names = set(package_forks.keys())
+
+    # Collect wheels from local directory or GitHub releases across forks
     wheels: dict[str, list[dict]] = {name: [] for name in package_names}
 
     if wheels_dir and os.path.isdir(wheels_dir):
@@ -85,11 +90,20 @@ def generate_index(wheels_dir: str | None, output_dir: str,
                     "sha256": sha,
                 })
     else:
-        for asset in get_release_assets(repo):
+        # Scan releases across all fork repos
+        fork_repos = {r for r in package_forks.values() if r}
+        print(f"Scanning releases in {len(fork_repos)} fork repos...")
+
+        all_assets = []
+        for repo in sorted(fork_repos):
+            print(f"  Checking {repo}...")
+            all_assets.extend(get_release_assets(repo))
+
+        for asset in all_assets:
             name = normalize_name(asset["name"].split("-")[0])
             if name in wheels:
                 download_url = (
-                    f"https://github.com/{repo}/releases/download/"
+                    f"https://github.com/{asset['repo']}/releases/download/"
                     f"{asset['tag']}/{asset['name']}"
                 )
                 wheels[name].append({


### PR DESCRIPTION
## Summary
- Update `generate-index.py` to scan releases across all fork repos instead of only this repo
- Add `fork` field to `packages.json` mapping each package to its `gounthar/` fork
- Fix blake3 source to `oconnor663/blake3-py` (the actual Python package repo)
- Add manual dispatch + daily schedule to index workflow

Each fork repo now builds wheels and creates its own GitHub Release. This index
aggregates them into a single PEP 503 endpoint for `pip install --extra-index-url`.