### PR TITLE
Expand package list with all built riscv64 wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ Many Python packages with native extensions (Rust, C, C++) lack official riscv64
 pip install PACKAGE --find-links https://github.com/gounthar/riscv64-python-wheels/releases/download/RELEASE_TAG/
 ```
 
-Replace `PACKAGE` with the package name and `RELEASE_TAG` with the release version.
+Replace `PACKAGE` with the package name and `RELEASE_TAG` with the release version (e.g., `v2026.03.07-cp313`).
+
+### Install multiple packages at once
+
+```bash
+pip install tokenizers pydantic-core safetensors cryptography \
+  --find-links https://github.com/gounthar/riscv64-python-wheels/releases/download/v2026.03.07-cp313/
+```
 
 ### Via PEP 503 index (coming soon)
 
@@ -22,32 +29,52 @@ pip install PACKAGE --extra-index-url https://gounthar.github.io/riscv64-python-
 
 ## Supported Packages
 
-| Package | Version | Python | Source Language | Status |
-|---------|---------|--------|----------------|--------|
-| tokenizers | - | cp313 | Rust | Planned |
-| pydantic-core | - | cp313 | Rust | Planned |
-| safetensors | - | cp313 | Rust | Planned |
-| tiktoken | - | cp313 | Rust | Planned |
-| blake3 | - | cp313 | Rust + C | Planned |
-| sentencepiece | - | cp313 | C++ | Planned |
-| pillow | - | cp313 | C | Planned |
+| Package | Version | Python | Source | Status |
+|---------|---------|--------|--------|--------|
+| pydantic-core | 2.41.5 | cp313 | Rust | Built |
+| tokenizers | 0.22.2 | cp39+ | Rust | Built |
+| sentencepiece | 0.2.1 | cp313 | C++ | Built |
+| cffi | 2.0.0 | cp313 | C | Built |
+| cryptography | 46.0.5 | cp313+ | Rust + C | Built |
+| watchfiles | 1.1.1 | cp313 | Rust | Built |
+| zstandard | 0.25.0 | cp313 | C | Built |
+| pyyaml | 6.0.3 | cp313 | C | Built |
+| tree-sitter | 0.25.2 | cp313 | C | Built |
+| tree-sitter-bash | 0.25.1 | cp310+ | C | Built |
+| textual-speedups | 0.2.1 | cp313 | Rust | Built |
+| safetensors | 0.7.0 | cp313 | Rust | Building |
+| tiktoken | 0.12.0 | cp313 | Rust | Building |
+| blake3 | 1.0.8 | cp313 | Rust + C | Building |
+| pillow | 12.1.1 | cp313 | C | Building |
 
 ## Build Hardware
 
-All wheels are built natively on:
+All wheels are built natively (no cross-compilation, no QEMU) on:
 
 - **BananaPi F3** (SpacemiT K1)
-- 8x rv64imafdcv cores @ 1.6 GHz
-- RVV 1.0 with vlen=256
+- 8x Spacemit X60 rv64imafdcv cores @ 1.6 GHz
+- RVV 1.0 with vlen=256, zvfh extensions
 - 16 GB RAM
-- Debian Linux
+- Debian trixie (testing), GCC 14.2, Python 3.13.5
+
+## Release Naming
+
+Releases are tagged as `v{YYYY.MM.DD}-cp{python_version}`, for example `v2026.03.07-cp313`.
+
+Each release contains all wheels for that Python version, plus a `SHA256SUMS` file for integrity verification.
 
 ## Scripts
 
-- `scripts/extract-wheels.sh` - Extract riscv64 wheels from pip cache
-- `scripts/build-from-source.sh` - Build a package wheel from source
-- `scripts/generate-index.py` - Generate PEP 503 compliant index
-- `scripts/check-upstream.sh` - Check for new upstream versions on PyPI
+| Script | Purpose |
+|--------|---------|
+| `scripts/extract-wheels.sh` | Extract riscv64 wheels from pip cache on the build machine |
+| `scripts/build-from-source.sh` | Build a package wheel from a forked source checkout |
+| `scripts/generate-index.py` | Generate PEP 503 compliant package index for GitHub Pages |
+| `scripts/check-upstream.sh` | Detect new upstream versions on PyPI |
+
+## Upstream Forks
+
+Each package is forked under [github.com/gounthar](https://github.com/gounthar) to enable future upstream PRs adding riscv64 to their official CI/wheel builds.
 
 ## Contributing
 

--- a/packages.json
+++ b/packages.json
@@ -1,12 +1,20 @@
 {
   "packages": [
-    {"name": "tokenizers", "version": null, "python": "cp313", "source": "huggingface/tokenizers", "fork": "gounthar/tokenizers", "lang": "rust", "status": "planned"},
-    {"name": "pydantic-core", "version": null, "python": "cp313", "source": "pydantic/pydantic-core", "fork": "gounthar/pydantic-core", "lang": "rust", "status": "planned"},
-    {"name": "safetensors", "version": null, "python": "cp313", "source": "huggingface/safetensors", "fork": "gounthar/safetensors", "lang": "rust", "status": "planned"},
-    {"name": "tiktoken", "version": null, "python": "cp313", "source": "openai/tiktoken", "fork": "gounthar/tiktoken", "lang": "rust", "status": "planned"},
-    {"name": "blake3", "version": null, "python": "cp313", "source": "oconnor663/blake3-py", "fork": "gounthar/blake3-py", "lang": "rust+c", "status": "planned"},
-    {"name": "sentencepiece", "version": null, "python": "cp313", "source": "google/sentencepiece", "fork": "gounthar/sentencepiece", "lang": "c++", "status": "planned"},
-    {"name": "pillow", "version": null, "python": "cp313", "source": "python-pillow/Pillow", "fork": "gounthar/Pillow", "lang": "c", "status": "planned"}
+    {"name": "pydantic-core", "version": "2.41.5", "python": "cp313", "source": "pydantic/pydantic-core", "fork": "gounthar/pydantic-core", "lang": "rust", "status": "built"},
+    {"name": "tokenizers", "version": "0.22.2", "python": "cp39-abi3", "source": "huggingface/tokenizers", "fork": "gounthar/tokenizers", "lang": "rust", "status": "built"},
+    {"name": "sentencepiece", "version": "0.2.1", "python": "cp313", "source": "google/sentencepiece", "fork": "gounthar/sentencepiece", "lang": "c++", "status": "built"},
+    {"name": "cffi", "version": "2.0.0", "python": "cp313", "source": "python-cffi/cffi", "fork": "gounthar/cffi", "lang": "c", "status": "built"},
+    {"name": "cryptography", "version": "46.0.5", "python": "cp313-abi3", "source": "pyca/cryptography", "fork": "gounthar/cryptography", "lang": "rust+c", "status": "built"},
+    {"name": "watchfiles", "version": "1.1.1", "python": "cp313", "source": "samuelcolvin/watchfiles", "fork": "gounthar/watchfiles", "lang": "rust", "status": "built"},
+    {"name": "zstandard", "version": "0.25.0", "python": "cp313", "source": "indygreg/python-zstandard", "fork": "gounthar/python-zstandard", "lang": "c", "status": "built"},
+    {"name": "pyyaml", "version": "6.0.3", "python": "cp313", "source": "yaml/pyyaml", "fork": "gounthar/pyyaml", "lang": "c", "status": "built"},
+    {"name": "tree-sitter", "version": "0.25.2", "python": "cp313", "source": "tree-sitter/py-tree-sitter", "fork": "gounthar/py-tree-sitter", "lang": "c", "status": "built"},
+    {"name": "tree-sitter-bash", "version": "0.25.1", "python": "cp310-abi3", "source": "tree-sitter/tree-sitter-bash", "fork": "gounthar/tree-sitter-bash", "lang": "c", "status": "built"},
+    {"name": "textual-speedups", "version": "0.2.1", "python": "cp313", "source": "Textualize/textual", "fork": "gounthar/textual", "lang": "rust", "status": "built"},
+    {"name": "safetensors", "version": "0.7.0", "python": "cp313", "source": "huggingface/safetensors", "fork": "gounthar/safetensors", "lang": "rust", "status": "building"},
+    {"name": "tiktoken", "version": "0.12.0", "python": "cp313", "source": "openai/tiktoken", "fork": "gounthar/tiktoken", "lang": "rust", "status": "building"},
+    {"name": "blake3", "version": "1.0.8", "python": "cp313", "source": "BLAKE3-team/BLAKE3", "fork": "gounthar/BLAKE3", "lang": "rust+c", "status": "building"},
+    {"name": "pillow", "version": "12.1.1", "python": "cp313", "source": "python-pillow/Pillow", "fork": "gounthar/Pillow", "lang": "c", "status": "building"}
   ],
   "build_target": {
     "arch": "riscv64",


### PR DESCRIPTION
## Summary

- Add 8 new packages to the manifest that were successfully built on the BananaPi F3
- Update README with actual versions, improved install examples, and upstream fork docs
- Total: 15 packages tracked (11 built, 4 building)

## New packages added

| Package | Version | Source |
|---------|---------|--------|
| cffi | 2.0.0 | C |
| cryptography | 46.0.5 | Rust + C |
| watchfiles | 1.1.1 | Rust |
| zstandard | 0.25.0 | C |
| pyyaml | 6.0.3 | C |
| tree-sitter | 0.25.2 | C |
| tree-sitter-bash | 0.25.1 | C |
| textual-speedups | 0.2.1 | Rust |

## Test plan

- [ ] Verify packages.json is valid JSON
- [ ] Verify README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation instructions with concrete release tag examples.
  * Restructured package support table to display current build statuses instead of planned entries.
  * Added Release Naming scheme documentation explaining the versioning format.
  * Introduced Scripts section detailing each script's purpose.
  * Added Upstream Forks section for package source transparency.
  * Expanded Build Hardware specification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->