### PR TITLE
ci: close the loop for automated wheel aggregation

### DIFF
--- a/.github/workflows/update-index.yml
+++ b/.github/workflows/update-index.yml
@@ -1,17 +1,25 @@
-name: Update PEP 503 index
+name: Aggregate wheels and update PEP 503 index
+
+# This workflow:
+#   1. Scans all fork repos for riscv64 wheel releases
+#   2. Downloads new wheels not yet in the central release
+#   3. Creates/updates a dated central release with all wheels
+#   4. Regenerates the PEP 503 simple index on GitHub Pages
+#
+# Triggers:
+#   - Daily at 6 AM UTC (after nightly builds complete)
+#   - Manual dispatch
+#   - repository_dispatch from fork workflows after they publish a release
 
 on:
-  # Manual trigger
-  workflow_dispatch:
-  # Scheduled: daily at 3 AM UTC (after weekly builds complete)
   schedule:
-    - cron: '0 3 * * *'
-  # When this repo gets a release (fallback)
-  release:
-    types: [published]
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [fork-release-published]
 
 jobs:
-  update-index:
+  aggregate-and-index:
     runs-on: ubuntu-latest
 
     permissions:
@@ -26,13 +34,15 @@ jobs:
         with:
           python-version: '3.13'
 
-      - name: Generate PEP 503 index from fork releases
+      - name: Aggregate wheels from fork releases
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python scripts/generate-index.py "" .
+        run: bash scripts/aggregate-wheels.sh
 
-      - name: Deploy to gh-pages
+      - name: Generate PEP 503 index from downloaded wheels
+        run: python scripts/generate-index.py wheels .
+
+      - name: Deploy index to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/packages.json
+++ b/packages.json
@@ -11,10 +11,10 @@
     {"name": "tree-sitter", "version": "0.25.2", "python": "cp313", "source": "tree-sitter/py-tree-sitter", "fork": "gounthar/py-tree-sitter", "lang": "c", "status": "built"},
     {"name": "tree-sitter-bash", "version": "0.25.1", "python": "cp310-abi3", "source": "tree-sitter/tree-sitter-bash", "fork": "gounthar/tree-sitter-bash", "lang": "c", "status": "built"},
     {"name": "textual-speedups", "version": "0.2.1", "python": "cp313", "source": "Textualize/textual", "fork": "gounthar/textual", "lang": "rust", "status": "built"},
-    {"name": "safetensors", "version": "0.7.0", "python": "cp313", "source": "huggingface/safetensors", "fork": "gounthar/safetensors", "lang": "rust", "status": "building"},
-    {"name": "tiktoken", "version": "0.12.0", "python": "cp313", "source": "openai/tiktoken", "fork": "gounthar/tiktoken", "lang": "rust", "status": "building"},
-    {"name": "blake3", "version": "1.0.8", "python": "cp313", "source": "BLAKE3-team/BLAKE3", "fork": "gounthar/BLAKE3", "lang": "rust+c", "status": "building"},
-    {"name": "pillow", "version": "12.1.1", "python": "cp313", "source": "python-pillow/Pillow", "fork": "gounthar/Pillow", "lang": "c", "status": "building"}
+    {"name": "safetensors", "version": "0.7.0", "python": "cp38-abi3", "source": "huggingface/safetensors", "fork": "gounthar/safetensors", "lang": "rust", "status": "built"},
+    {"name": "tiktoken", "version": "0.12.0", "python": "cp313", "source": "openai/tiktoken", "fork": "gounthar/tiktoken", "lang": "rust", "status": "built"},
+    {"name": "blake3", "version": "1.0.8", "python": "cp313", "source": "oconnor663/blake3-py", "fork": "gounthar/blake3-py", "lang": "rust+c", "status": "built"},
+    {"name": "pillow", "version": "12.1.1", "python": "cp313", "source": "python-pillow/Pillow", "fork": "gounthar/Pillow", "lang": "c", "status": "built"}
   ],
   "build_target": {
     "arch": "riscv64",

--- a/scripts/aggregate-wheels.sh
+++ b/scripts/aggregate-wheels.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+
+# Aggregate riscv64 wheels from fork repo releases into a central release.
+#
+# For each package in packages.json:
+#   1. Check the fork repo for GitHub Releases with riscv64 wheels
+#   2. Download any wheels not already in our central release
+#   3. Create or update the central release with all wheels
+#
+# Requires: gh (authenticated), jq, curl
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGES_FILE="${SCRIPT_DIR}/../packages.json"
+WHEELS_DIR="${SCRIPT_DIR}/../wheels"
+CENTRAL_REPO="gounthar/riscv64-python-wheels"
+
+# Dependency checks
+for cmd in jq gh; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is required but not installed."
+        exit 1
+    fi
+done
+
+if [ ! -f "$PACKAGES_FILE" ]; then
+    echo "Error: packages.json not found at $PACKAGES_FILE"
+    exit 1
+fi
+
+mkdir -p "$WHEELS_DIR"
+
+# Get existing wheels in the latest central release
+echo "Checking existing central release..."
+EXISTING_WHEELS=""
+LATEST_TAG=$(gh release list --repo "$CENTRAL_REPO" --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null || echo "")
+
+if [ -n "$LATEST_TAG" ]; then
+    echo "  Latest release: $LATEST_TAG"
+    EXISTING_WHEELS=$(gh release view "$LATEST_TAG" --repo "$CENTRAL_REPO" --json assets --jq '.assets[].name' 2>/dev/null || echo "")
+    # Download existing wheels so we have a complete set
+    if [ -n "$EXISTING_WHEELS" ]; then
+        echo "  Downloading existing wheels..."
+        gh release download "$LATEST_TAG" --repo "$CENTRAL_REPO" --dir "$WHEELS_DIR" --pattern "*.whl" 2>/dev/null || true
+    fi
+else
+    echo "  No existing release found."
+fi
+
+# Scan each fork repo for new wheels
+echo ""
+echo "Scanning fork repos for new wheels..."
+PACKAGE_COUNT=$(jq '.packages | length' "$PACKAGES_FILE")
+NEW_WHEELS=0
+
+for i in $(seq 0 $((PACKAGE_COUNT - 1))); do
+    name=$(jq -r ".packages[$i].name" "$PACKAGES_FILE")
+    fork=$(jq -r ".packages[$i].fork" "$PACKAGES_FILE")
+
+    if [ -z "$fork" ] || [ "$fork" = "null" ]; then
+        continue
+    fi
+
+    printf "  %-20s  checking %s..." "$name" "$fork"
+
+    # List releases in the fork
+    FORK_RELEASES=$(gh release list --repo "$fork" --json tagName --jq '.[].tagName' 2>/dev/null || echo "")
+
+    if [ -z "$FORK_RELEASES" ]; then
+        printf " no releases\n"
+        continue
+    fi
+
+    FOUND=0
+    for tag in $FORK_RELEASES; do
+        # Get wheel assets from this release
+        ASSETS=$(gh release view "$tag" --repo "$fork" --json assets --jq '.assets[] | select(.name | endswith(".whl")) | .name' 2>/dev/null || echo "")
+
+        for asset_name in $ASSETS; do
+            if [ -z "$asset_name" ]; then
+                continue
+            fi
+
+            # Skip if we already have this exact wheel
+            if [ -f "$WHEELS_DIR/$asset_name" ]; then
+                continue
+            fi
+
+            # Download the new wheel
+            gh release download "$tag" --repo "$fork" --dir "$WHEELS_DIR" --pattern "$asset_name" 2>/dev/null || true
+
+            if [ -f "$WHEELS_DIR/$asset_name" ]; then
+                FOUND=$((FOUND + 1))
+                NEW_WHEELS=$((NEW_WHEELS + 1))
+            fi
+        done
+    done
+
+    if [ "$FOUND" -gt 0 ]; then
+        printf " +%d new wheel(s)\n" "$FOUND"
+    else
+        printf " up to date\n"
+    fi
+done
+
+echo ""
+
+# Count total wheels
+TOTAL=$(find "$WHEELS_DIR" -name "*.whl" 2>/dev/null | wc -l)
+echo "Total wheels: $TOTAL ($NEW_WHEELS new)"
+
+if [ "$TOTAL" -eq 0 ]; then
+    echo "No wheels found. Nothing to release."
+    exit 0
+fi
+
+# Generate checksums
+cd "$WHEELS_DIR"
+sha256sum *.whl > SHA256SUMS 2>/dev/null || true
+
+# Create or update central release
+RELEASE_TAG="v$(date -u +%Y.%m.%d)-cp313"
+RELEASE_TITLE="riscv64 wheels for CPython 3.13 ($(date -u +%Y-%m-%d))"
+
+echo ""
+echo "Creating/updating release: $RELEASE_TAG"
+
+# Build package table for release notes
+PACKAGE_TABLE=""
+for whl in *.whl; do
+    [ "$whl" = "*.whl" ] && continue
+    pkg_name=$(echo "$whl" | sed 's/-[0-9].*//' | tr '_' '-')
+    pkg_version=$(echo "$whl" | sed 's/^[^-]*-\([^-]*\)-.*/\1/')
+    abi=$(echo "$whl" | sed 's/.*-\(cp[^-]*\)-.*riscv64.whl/\1/')
+    PACKAGE_TABLE="${PACKAGE_TABLE}| ${pkg_name} | ${pkg_version} | ${abi} |\n"
+done
+
+RELEASE_NOTES=$(cat <<NOTES
+Prebuilt Python wheels for RISC-V 64-bit (riscv64) Linux.
+
+## Packages
+
+| Package | Version | ABI |
+|---------|---------|-----|
+$(echo -e "$PACKAGE_TABLE")
+## Build hardware
+
+BananaPi F3 (SpacemiT K1, 8x rv64imafdcv @ 1.6 GHz, RVV 1.0 vlen=256, 16 GB RAM)
+
+## Install
+
+\`\`\`bash
+pip install PACKAGE --extra-index-url https://gounthar.github.io/riscv64-python-wheels/simple/
+\`\`\`
+
+Or install directly from this release:
+\`\`\`bash
+pip install PACKAGE --find-links https://github.com/gounthar/riscv64-python-wheels/releases/expanded_assets/${RELEASE_TAG}
+\`\`\`
+
+## Checksums
+
+See SHA256SUMS file attached to this release.
+NOTES
+)
+
+# Delete existing release with same tag if it exists
+gh release delete "$RELEASE_TAG" --repo "$CENTRAL_REPO" --yes 2>/dev/null || true
+
+# Create release
+gh release create "$RELEASE_TAG" \
+    --repo "$CENTRAL_REPO" \
+    --title "$RELEASE_TITLE" \
+    --notes "$RELEASE_NOTES" \
+    *.whl SHA256SUMS
+
+echo ""
+echo "Release published: https://github.com/$CENTRAL_REPO/releases/tag/$RELEASE_TAG"

--- a/scripts/generate-index.py
+++ b/scripts/generate-index.py
@@ -63,6 +63,19 @@ def get_release_assets(repo: str) -> list[dict]:
     return assets
 
 
+def _find_release_tag(repo: str) -> str:
+    """Get the latest release tag from a repo."""
+    try:
+        result = subprocess.run(
+            ["gh", "release", "list", "--repo", repo, "--limit", "1",
+             "--json", "tagName", "--jq", ".[0].tagName"],
+            capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
 def generate_index(wheels_dir: str | None, output_dir: str) -> None:
     packages_file = Path(__file__).parent.parent / "packages.json"
     with open(packages_file) as f:
@@ -79,29 +92,46 @@ def generate_index(wheels_dir: str | None, output_dir: str) -> None:
     # Collect wheels from local directory or GitHub releases across forks
     wheels: dict[str, list[dict]] = {name: [] for name in package_names}
 
+    central_repo = "gounthar/riscv64-python-wheels"
+
     if wheels_dir and os.path.isdir(wheels_dir):
+        # Local mode: index wheels from a directory (with sha256 integrity)
         for whl_file in Path(wheels_dir).glob("*.whl"):
             name = normalize_name(whl_file.name.split("-")[0])
             if name in wheels:
                 sha = sha256_file(str(whl_file))
+                # Link to central repo release asset
+                tag = _find_release_tag(central_repo)
+                if tag:
+                    url = (
+                        f"https://github.com/{central_repo}/"
+                        f"releases/download/{tag}/{whl_file.name}"
+                    )
+                else:
+                    url = whl_file.name
                 wheels[name].append({
                     "filename": whl_file.name,
-                    "url": whl_file.name,
+                    "url": url,
                     "sha256": sha,
                 })
     else:
-        # Scan releases across all fork repos
-        fork_repos = {r for r in package_forks.values() if r}
-        print(f"Scanning releases in {len(fork_repos)} fork repos...")
+        # Remote mode: scan central repo releases first, then fork repos
+        print(f"Scanning central repo {central_repo}...")
+        all_assets = get_release_assets(central_repo)
 
-        all_assets = []
+        # Also scan fork repos for wheels not in central
+        fork_repos = {r for r in package_forks.values() if r}
+        print(f"Scanning {len(fork_repos)} fork repos...")
         for repo in sorted(fork_repos):
             print(f"  Checking {repo}...")
             all_assets.extend(get_release_assets(repo))
 
+        # Deduplicate: prefer central repo, keep latest version per filename
+        seen: set[str] = set()
         for asset in all_assets:
             name = normalize_name(asset["name"].split("-")[0])
-            if name in wheels:
+            if name in wheels and asset["name"] not in seen:
+                seen.add(asset["name"])
                 download_url = (
                     f"https://github.com/{asset['repo']}/releases/download/"
                     f"{asset['tag']}/{asset['name']}"

--- a/scripts/update-fork-workflows.sh
+++ b/scripts/update-fork-workflows.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+# Update build-riscv64.yml in all fork repos to add a dispatch callback
+# that triggers index regeneration in the central repo after publishing.
+#
+# This adds a final job that sends a repository_dispatch event to
+# gounthar/riscv64-python-wheels so the PEP 503 index gets updated
+# immediately after a new wheel is published.
+#
+# Requires: gh (authenticated with DISPATCH_TOKEN or equivalent PAT)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGES_FILE="${SCRIPT_DIR}/../packages.json"
+BRANCH="ci/add-index-callback"
+
+if [ ! -f "$PACKAGES_FILE" ]; then
+    echo "Error: packages.json not found"
+    exit 1
+fi
+
+# Dependency check
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed."
+    echo "Install with: sudo apt-get install jq"
+    exit 1
+fi
+
+# Read fork repos from packages.json
+FORKS=$(jq -r '.packages[].fork' "$PACKAGES_FILE" | sort -u | grep -v '^null$')
+
+CALLBACK_JOB='
+  notify-index:
+    needs: release
+    runs-on: ubuntu-latest
+    if: success()
+    steps:
+      - name: Trigger index update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/gounthar/riscv64-python-wheels/dispatches \
+            -f event_type=fork-release-published \
+            -f "client_payload[repo]=${{ github.repository }}" \
+            -f "client_payload[tag]=${{ github.ref_name }}" || true'
+
+echo "Adding index callback to fork workflows..."
+echo ""
+
+for fork in $FORKS; do
+    repo_name=$(basename "$fork")
+    printf "%-25s " "$repo_name"
+
+    # Check if workflow exists
+    WORKFLOW=$(gh api "repos/$fork/contents/.github/workflows/build-riscv64.yml" 2>/dev/null || echo "")
+    if [ -z "$WORKFLOW" ] || echo "$WORKFLOW" | jq -e '.message' &>/dev/null; then
+        echo "SKIP (no workflow)"
+        continue
+    fi
+
+    # Get current content
+    CONTENT=$(echo "$WORKFLOW" | jq -r '.content' | tr -d '\n' | base64 -d)
+    SHA=$(echo "$WORKFLOW" | jq -r '.sha')
+
+    # Check if callback already exists
+    if echo "$CONTENT" | grep -q "notify-index"; then
+        echo "already has callback"
+        continue
+    fi
+
+    # Append the callback job
+    UPDATED="${CONTENT}${CALLBACK_JOB}
+"
+
+    # Get default branch
+    DEFAULT_BRANCH=$(gh api "repos/$fork" --jq '.default_branch' 2>/dev/null)
+
+    # Get the SHA of the default branch head
+    BRANCH_SHA=$(gh api "repos/$fork/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha' 2>/dev/null)
+
+    # Check if our branch exists, delete if so
+    gh api -X DELETE "repos/$fork/git/refs/heads/$BRANCH" 2>/dev/null || true
+
+    # Create branch
+    gh api "repos/$fork/git/refs" \
+        -f ref="refs/heads/$BRANCH" \
+        -f sha="$BRANCH_SHA" > /dev/null 2>&1
+
+    # Update file on branch
+    ENCODED=$(echo "$UPDATED" | base64 -w0)
+    gh api "repos/$fork/contents/.github/workflows/build-riscv64.yml" \
+        -X PUT \
+        -f message="ci: add index update callback after release" \
+        -f content="$ENCODED" \
+        -f sha="$SHA" \
+        -f branch="$BRANCH" > /dev/null 2>&1
+
+    # Create PR
+    PR_URL=$(gh pr create --repo "$fork" \
+        --head "$BRANCH" \
+        --base "$DEFAULT_BRANCH" \
+        --title "ci: notify central index after wheel release" \
+        --body "$(cat <<'PREOF'
+## Summary
+
+Add a `notify-index` job to the riscv64 build workflow that triggers
+index regeneration in `gounthar/riscv64-python-wheels` after a new
+wheel release is published.
+
+This ensures the PEP 503 package index at
+https://gounthar.github.io/riscv64-python-wheels/simple/ is updated
+immediately when new wheels become available, rather than waiting for
+the daily cron.
+
+## Changes
+
+- Add `notify-index` job that sends `repository_dispatch` to the
+  central wheels repo after the `release` job succeeds
+PREOF
+)" 2>&1)
+
+    echo "PR: $PR_URL"
+done
+
+echo ""
+echo "Done. Review and merge the PRs to enable automatic index updates."


### PR DESCRIPTION
## Summary

Closes the automation gap between fork wheel builds and the central PEP 503 index.

### The problem

When a fork repo builds a new wheel and creates a release, the central index at
https://gounthar.github.io/riscv64-python-wheels/simple/ doesn't know about it.
Users can't install the new wheel until the index is manually updated.

### The solution

Three pieces that work together:

1. **`aggregate-wheels.sh`** — scans all fork repos for riscv64 wheel releases,
   downloads new wheels, creates/updates a central release with all wheels + checksums

2. **`update-index.yml`** — rewritten to run the aggregation, then regenerate the
   PEP 503 index and deploy to GitHub Pages. Triggers on:
   - Daily cron (6 AM UTC)
   - Manual dispatch
   - `repository_dispatch` from fork workflows (immediate)

3. **`update-fork-workflows.sh`** — adds a `notify-index` callback job to each
   fork's `build-riscv64.yml` that fires `repository_dispatch` after publishing
   a release, triggering immediate index regeneration

### Also fixed

- `packages.json`: all statuses set to `built`, blake3 fork corrected to `gounthar/blake3-py`
- `generate-index.py`: scans both central and fork releases, deduplicates, includes sha256

### The full automated flow

```
PyPI new version detected (midnight UTC)
  → detect-and-trigger.sh dispatches build in fork
  → fork builds wheel on riscv64 runner (self-hosted)
  → fork creates GitHub Release with wheel
  → fork dispatches repository_dispatch to central repo
  → aggregate-wheels.sh downloads wheel to central release
  → generate-index.py regenerates PEP 503 index
  → GitHub Pages deploys updated index
  → pip install works immediately
```

### Setup required

- **DISPATCH_TOKEN** secret (already created): PAT with `repo` + `workflow` scopes
- Run `scripts/update-fork-workflows.sh` after merge to add callbacks to fork repos

## Test plan

- [ ] Manually trigger `update-index.yml` via workflow_dispatch
- [ ] Verify it downloads wheels from fork releases
- [ ] Verify PEP 503 index is regenerated on GitHub Pages
- [ ] Run `update-fork-workflows.sh` and merge resulting PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Infrastructure**
  * Restructured build workflow to run on a daily schedule and automatically trigger when fork releases are published, replacing manual/weekly triggers.
  * Implemented centralized wheel aggregation system that consolidates wheels from multiple fork repositories.

* **Package Status Updates**
  * safetensors, tiktoken, blake3, and pillow packages now marked as built and available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->