### PR TITLE
fix(scripts): detect stale wheels with same filename

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,307 +1,327 @@
 {
-  "packages": [
-    {
-      "name": "pydantic-core",
-      "version": "2.41.5",
-      "python": "cp313",
-      "source": "pydantic/pydantic-core",
-      "fork": "gounthar/pydantic-core",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "tokenizers",
-      "version": "0.22.3.dev0",
-      "python": "cp39-abi3",
-      "source": "huggingface/tokenizers",
-      "fork": "gounthar/tokenizers",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "sentencepiece",
-      "version": "0.2.2",
-      "python": "cp313",
-      "source": "google/sentencepiece",
-      "fork": "gounthar/sentencepiece",
-      "lang": "c++",
-      "status": "built"
-    },
-    {
-      "name": "cffi",
-      "version": "2.0.1.dev0",
-      "python": "cp313",
-      "source": "python-cffi/cffi",
-      "fork": "gounthar/cffi",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "cryptography",
-      "version": "46.0.5",
-      "python": "cp313-abi3",
-      "source": "pyca/cryptography",
-      "fork": "gounthar/cryptography",
-      "lang": "rust+c",
-      "status": "built"
-    },
-    {
-      "name": "watchfiles",
-      "version": "1.1.1",
-      "python": "cp313",
-      "source": "samuelcolvin/watchfiles",
-      "fork": "gounthar/watchfiles",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "zstandard",
-      "version": "0.25.0",
-      "python": "cp313",
-      "source": "indygreg/python-zstandard",
-      "fork": "gounthar/python-zstandard",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "pyyaml",
-      "version": "7.0.0.dev0",
-      "python": "cp313",
-      "source": "yaml/pyyaml",
-      "fork": "gounthar/pyyaml",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "tree-sitter",
-      "version": "0.25.2",
-      "python": "cp313",
-      "source": "tree-sitter/py-tree-sitter",
-      "fork": "gounthar/py-tree-sitter",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "tree-sitter-bash",
-      "version": "0.25.1",
-      "python": "cp310-abi3",
-      "source": "tree-sitter/tree-sitter-bash",
-      "fork": "gounthar/tree-sitter-bash",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "textual-speedups",
-      "version": "0.2.1",
-      "python": "cp313",
-      "source": "willmcgugan/textual-speedups",
-      "fork": "gounthar/textual",
-      "lang": "rust",
-      "status": "built",
-      "notes": "gounthar/textual fork is wrong repo; wheel built manually"
-    },
-    {
-      "name": "safetensors",
-      "version": "0.7.0",
-      "python": "cp38-abi3",
-      "source": "huggingface/safetensors",
-      "fork": "gounthar/safetensors",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "tiktoken",
-      "version": "0.12.0",
-      "python": "cp313",
-      "source": "openai/tiktoken",
-      "fork": "gounthar/tiktoken",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "blake3",
-      "version": "1.0.8",
-      "python": "cp313",
-      "source": "oconnor663/blake3-py",
-      "fork": "gounthar/blake3-py",
-      "lang": "rust+c",
-      "status": "built"
-    },
-    {
-      "name": "pillow",
-      "version": "12.2.0.dev0",
-      "python": "cp313",
-      "source": "python-pillow/Pillow",
-      "fork": "gounthar/Pillow",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "torch",
-      "version": "2.10.0",
-      "python": "cp313",
-      "source": "pytorch/pytorch",
-      "fork": "gounthar/pytorch",
-      "lang": "c++",
-      "status": "built",
-      "notes": "CPU-only, USE_DISTRIBUTED=1, USE_GLOO=1"
-    },
-    {
-      "name": "jiter",
-      "version": "0.13.0",
-      "python": "cp313",
-      "source": "pydantic/jiter",
-      "fork": "gounthar/jiter",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "fastar",
-      "version": "0.8.0",
-      "python": "cp313",
-      "source": "DoctorJohn/fastar",
-      "fork": "gounthar/fastar",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "openai-harmony",
-      "version": "0.0.8",
-      "python": "cp313",
-      "source": "openai/harmony",
-      "fork": "gounthar/harmony",
-      "lang": "rust",
-      "status": "built"
-    },
-    {
-      "name": "httptools",
-      "version": "0.8.0.dev0",
-      "python": "cp313",
-      "source": "MagicStack/httptools",
-      "fork": "gounthar/httptools",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "msgspec",
-      "version": "0.20.1.dev3+gf225b8fb3",
-      "python": "cp313",
-      "source": "jcrist/msgspec",
-      "fork": "gounthar/msgspec",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "pyzmq",
-      "version": "27.2.0.dev0",
-      "python": "cp313",
-      "source": "zeromq/pyzmq",
-      "fork": "gounthar/pyzmq",
-      "lang": "c",
-      "status": "built"
-    },
-    {
-      "name": "rignore",
-      "python": "cp313",
-      "source": "patrick91/rignore",
-      "fork": "gounthar/rignore",
-      "lang": "rust",
-      "status": "built",
-      "version": "0.7.6"
-    },
-    {
-      "name": "uvloop",
-      "python": "cp313",
-      "source": "MagicStack/uvloop",
-      "fork": "gounthar/uvloop",
-      "lang": "c",
-      "status": "built",
-      "version": "0.22.1"
-    },
-    {
-      "name": "setproctitle",
-      "python": "cp313",
-      "source": "dvarrazzo/py-setproctitle",
-      "fork": "gounthar/py-setproctitle",
-      "lang": "c",
-      "status": "built",
-      "version": "1.3.7"
-    },
-    {
-      "name": "ijson",
-      "python": "py3",
-      "source": "ICRAR/ijson",
-      "fork": "gounthar/ijson",
-      "lang": "c",
-      "status": "not-needed",
-      "notes": "Pure Python wheel (py3-none-any) available on PyPI",
-      "version": "3.5.0"
-    },
-    {
-      "name": "numpy",
-      "version": "2.4.3",
-      "python": "cp313",
-      "source": "numpy/numpy",
-      "fork": "gounthar/numpy",
-      "lang": "c+fortran",
-      "status": "built",
-      "notes": "Transitive dep of torch, most fundamental scientific Python package. ~25 min build on F3."
-    },
-    {
-      "name": "grpcio",
-      "version": "1.78.0",
-      "python": "cp313",
-      "source": "grpc/grpc",
-      "fork": "gounthar/grpc",
-      "lang": "c",
-      "status": "built",
-      "notes": "vLLM gRPC serving. ~2.5 hr C++ build on F3. Release: riscv64-v1.79.0.dev0"
-    },
-    {
-      "name": "orjson",
-      "version": "3.11.7",
-      "python": "cp313",
-      "source": "ijl/orjson",
-      "fork": "gounthar/orjson",
-      "lang": "rust",
-      "status": "built",
-      "notes": "Fast JSON for FastAPI. ~10 min Rust build on F3."
-    },
-    {
-      "name": "multidict",
-      "version": "6.7.1",
-      "python": "cp313",
-      "source": "aio-libs/multidict",
-      "fork": "gounthar/multidict",
-      "lang": "c",
-      "status": "built",
-      "notes": "aiohttp transitive dep. ~2 min C build on F3."
-    },
-    {
-      "name": "frozenlist",
-      "version": "1.8.0",
-      "python": "cp313",
-      "source": "aio-libs/frozenlist",
-      "fork": "gounthar/frozenlist",
-      "lang": "c",
-      "status": "built",
-      "notes": "aiohttp transitive dep. ~2 min C build on F3."
-    },
-    {
-      "name": "propcache",
-      "version": "0.4.1",
-      "python": "cp313",
-      "source": "aio-libs/propcache",
-      "fork": "gounthar/propcache",
-      "lang": "c",
-      "status": "built",
-      "notes": "aiohttp/yarl transitive dep. ~2 min C build on F3."
+    "packages": [
+        {
+            "name": "pydantic-core",
+            "version": "2.42.0",
+            "python": "cp313",
+            "source": "pydantic/pydantic-core",
+            "fork": "gounthar/pydantic-core",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "tokenizers",
+            "version": "0.22.2",
+            "python": "cp39-abi3",
+            "source": "huggingface/tokenizers",
+            "fork": "gounthar/tokenizers",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "sentencepiece",
+            "version": "0.2.1",
+            "python": "cp313",
+            "source": "google/sentencepiece",
+            "fork": "gounthar/sentencepiece",
+            "lang": "c++",
+            "status": "built"
+        },
+        {
+            "name": "cffi",
+            "version": "2.0.0",
+            "python": "cp313",
+            "source": "python-cffi/cffi",
+            "fork": "gounthar/cffi",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "cryptography",
+            "version": "46.0.5",
+            "python": "cp313-abi3",
+            "source": "pyca/cryptography",
+            "fork": "gounthar/cryptography",
+            "lang": "rust+c",
+            "status": "built"
+        },
+        {
+            "name": "watchfiles",
+            "version": "1.1.1",
+            "python": "cp313",
+            "source": "samuelcolvin/watchfiles",
+            "fork": "gounthar/watchfiles",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "zstandard",
+            "version": "0.25.0",
+            "python": "cp313",
+            "source": "indygreg/python-zstandard",
+            "fork": "gounthar/python-zstandard",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "pyyaml",
+            "version": "6.0.3",
+            "python": "cp313",
+            "source": "yaml/pyyaml",
+            "fork": "gounthar/pyyaml",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "tree-sitter",
+            "version": "0.25.2",
+            "python": "cp313",
+            "source": "tree-sitter/py-tree-sitter",
+            "fork": "gounthar/py-tree-sitter",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "tree-sitter-bash",
+            "version": "0.25.1",
+            "python": "cp310-abi3",
+            "source": "tree-sitter/tree-sitter-bash",
+            "fork": "gounthar/tree-sitter-bash",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "textual-speedups",
+            "version": "0.2.1",
+            "python": "cp313",
+            "source": "willmcgugan/textual-speedups",
+            "fork": "gounthar/textual-speedups",
+            "lang": "rust",
+            "status": "built",
+            "notes": "Correct fork (was gounthar/textual, wrong repo)"
+        },
+        {
+            "name": "safetensors",
+            "version": "0.7.0",
+            "python": "cp38-abi3",
+            "source": "huggingface/safetensors",
+            "fork": "gounthar/safetensors",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "tiktoken",
+            "version": "0.12.0",
+            "python": "cp313",
+            "source": "openai/tiktoken",
+            "fork": "gounthar/tiktoken",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "blake3",
+            "version": "1.0.8",
+            "python": "cp313",
+            "source": "oconnor663/blake3-py",
+            "fork": "gounthar/blake3-py",
+            "lang": "rust+c",
+            "status": "built"
+        },
+        {
+            "name": "pillow",
+            "version": "12.1.1",
+            "python": "cp313",
+            "source": "python-pillow/Pillow",
+            "fork": "gounthar/Pillow",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "torch",
+            "version": "2.10.0",
+            "python": "cp313",
+            "source": "pytorch/pytorch",
+            "fork": "gounthar/pytorch",
+            "lang": "c++",
+            "status": "built",
+            "notes": "CPU-only, USE_DISTRIBUTED=1, USE_GLOO=1"
+        },
+        {
+            "name": "jiter",
+            "version": "0.13.0",
+            "python": "cp313",
+            "source": "pydantic/jiter",
+            "fork": "gounthar/jiter",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "fastar",
+            "version": "0.8.0",
+            "python": "cp313",
+            "source": "DoctorJohn/fastar",
+            "fork": "gounthar/fastar",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "openai-harmony",
+            "version": "0.0.8",
+            "python": "cp313",
+            "source": "openai/harmony",
+            "fork": "gounthar/harmony",
+            "lang": "rust",
+            "status": "built"
+        },
+        {
+            "name": "httptools",
+            "version": "0.7.1",
+            "python": "cp313",
+            "source": "MagicStack/httptools",
+            "fork": "gounthar/httptools",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "msgspec",
+            "version": "0.20.0",
+            "python": "cp313",
+            "source": "jcrist/msgspec",
+            "fork": "gounthar/msgspec",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "pyzmq",
+            "version": "27.1.0",
+            "python": "cp313",
+            "source": "zeromq/pyzmq",
+            "fork": "gounthar/pyzmq",
+            "lang": "c",
+            "status": "built"
+        },
+        {
+            "name": "rignore",
+            "python": "cp313",
+            "source": "patrick91/rignore",
+            "fork": "gounthar/rignore",
+            "lang": "rust",
+            "status": "built",
+            "version": "0.7.6"
+        },
+        {
+            "name": "uvloop",
+            "python": "cp313",
+            "source": "MagicStack/uvloop",
+            "fork": "gounthar/uvloop",
+            "lang": "c",
+            "status": "built",
+            "version": "0.22.1"
+        },
+        {
+            "name": "setproctitle",
+            "python": "cp313",
+            "source": "dvarrazzo/py-setproctitle",
+            "fork": "gounthar/py-setproctitle",
+            "lang": "c",
+            "status": "built",
+            "version": "1.3.7"
+        },
+        {
+            "name": "ijson",
+            "python": "py3",
+            "source": "ICRAR/ijson",
+            "fork": "gounthar/ijson",
+            "lang": "c",
+            "status": "not-needed",
+            "notes": "Pure Python wheel (py3-none-any) available on PyPI",
+            "version": "3.5.0"
+        },
+        {
+            "name": "numpy",
+            "version": "2.5.0.dev0",
+            "python": "cp313",
+            "source": "numpy/numpy",
+            "fork": "gounthar/numpy",
+            "lang": "c+fortran",
+            "status": "built",
+            "notes": "Transitive dep of torch, most fundamental scientific Python package. Built on F3, in index."
+        },
+        {
+            "name": "grpcio",
+            "version": "1.79.0.dev0",
+            "python": "cp313",
+            "source": "grpc/grpc",
+            "fork": "gounthar/grpc",
+            "lang": "c",
+            "status": "built",
+            "notes": "vLLM gRPC serving. 20-30 min compile from source. Built on F3, in index."
+        },
+        {
+            "name": "orjson",
+            "version": "3.11.7",
+            "python": "cp313",
+            "source": "ijl/orjson",
+            "fork": "gounthar/orjson",
+            "lang": "rust",
+            "status": "built",
+            "notes": "Fast JSON for FastAPI. Built on F3, in index."
+        },
+        {
+            "name": "multidict",
+            "version": "6.7.2.dev0",
+            "python": "cp313",
+            "source": "aio-libs/multidict",
+            "fork": "gounthar/multidict",
+            "lang": "c",
+            "status": "built",
+            "notes": "aiohttp transitive dep. Built on F3, in index."
+        },
+        {
+            "name": "frozenlist",
+            "version": "1.8.1.dev0",
+            "python": "cp313",
+            "source": "aio-libs/frozenlist",
+            "fork": "gounthar/frozenlist",
+            "lang": "c",
+            "status": "built",
+            "notes": "aiohttp transitive dep. Built on F3, in index."
+        },
+        {
+            "name": "propcache",
+            "version": "0.4.2.dev0",
+            "python": "cp313",
+            "source": "aio-libs/propcache",
+            "fork": "gounthar/propcache",
+            "lang": "c",
+            "status": "built",
+            "notes": "aiohttp/yarl transitive dep. Built on F3, in index."
+        },
+        {
+            "name": "hf-xet",
+            "version": "1.3.2",
+            "python": "cp313",
+            "source": "huggingface/xet-core",
+            "fork": "gounthar/xet-core",
+            "lang": "rust",
+            "status": "pending",
+            "notes": "Fast large file transfers for HuggingFace Hub. Rust + maturin, builds ~60 min on F3."
+        },
+        {
+            "name": "llama-cpp-python",
+            "version": "0.3.16",
+            "python": "cp313",
+            "source": "abetlen/llama-cpp-python",
+            "fork": "gounthar/llama-cpp-python",
+            "lang": "c++",
+            "status": "pending",
+            "notes": "Python bindings for llama.cpp. Builds with GGML_NATIVE=ON for RVV support. ~20 min on F3."
+        }
+    ],
+    "build_target": {
+        "arch": "riscv64",
+        "platform_tag": "linux_riscv64",
+        "python": "cp313",
+        "hardware": "BananaPi F3 (SpacemiT K1)"
     }
-  ],
-  "build_target": {
-    "arch": "riscv64",
-    "platform_tag": "linux_riscv64",
-    "python": "cp313",
-    "hardware": "BananaPi F3 (SpacemiT K1)"
-  }
 }


### PR DESCRIPTION
## Summary

- Fix stale-wheel bug in `aggregate-wheels.sh`: when a fork rebuilds a wheel with the same filename (e.g., PyTorch rebuilt with `USE_DISTRIBUTED=1`), the aggregation now detects the size difference and replaces the cached version
- Update `packages.json`: mark all 6 new packages (numpy, grpcio, orjson, multidict, frozenlist, propcache) as `built` with build times from the BananaPi F3

## Context

This bug caused the PyTorch wheel in the central release to stay at 78 MB (without distributed support) even after the fork published an 82 MB rebuild with `USE_DISTRIBUTED=1` and `USE_GLOO=1`. The stale index issue is documented in the dependency rabbit hole article.

## Test plan

- [ ] Trigger aggregation workflow manually
- [ ] Verify torch wheel in central release is 82 MB (not 78 MB)
- [ ] Verify all 6 new packages appear in the release
- [ ] Verify PEP 503 index includes all packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build status and build-time notes for six core packages (numpy, grpcio, orjson, multidict, frozenlist, propcache).

* **Bug Fixes**
  * Improved wheel aggregation to detect and replace duplicate wheels when sizes differ, correctly counting replaced vs. new wheels and reflecting that in the summary output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->