### PR TITLE
chore: add hf-xet to package list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -296,6 +296,16 @@
       "lang": "c",
       "status": "pending",
       "notes": "aiohttp/yarl transitive dep. No riscv64 wheel on PyPI."
+    },
+    {
+      "name": "hf-xet",
+      "version": "1.3.2",
+      "python": "cp313",
+      "source": "huggingface/xet-core",
+      "fork": "gounthar/xet-core",
+      "lang": "rust",
+      "status": "pending",
+      "notes": "Fast large file transfers for HuggingFace Hub. Rust + maturin, builds ~60 min on F3."
     }
   ],
   "build_target": {


### PR DESCRIPTION
## Summary
- Add hf-xet (huggingface/xet-core) to packages.json
- Fork at gounthar/xet-core with build-riscv64.yml workflow
- Rust + maturin, builds in ~60 min on BananaPi F3
- v1.3.2 successfully built from source on F3 (confirmed in vllm-env)

## Test plan
- [ ] Trigger build workflow on gounthar/xet-core
- [ ] Verify wheel appears in release
- [ ] Verify PEP 503 index picks it up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new package entry to the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->