### PR TITLE
chore: stop building wheels upstream now publishes

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7,7 +7,8 @@
       "source": "pydantic/pydantic-core",
       "fork": "gounthar/pydantic-core",
       "lang": "rust",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (8 wheels in 2.48.0); no local build needed"
     },
     {
       "name": "tokenizers",
@@ -16,7 +17,8 @@
       "source": "huggingface/tokenizers",
       "fork": "gounthar/tokenizers",
       "lang": "rust",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (1 wheel in 0.23.1); no local build needed"
     },
     {
       "name": "sentencepiece",
@@ -52,7 +54,8 @@
       "source": "samuelcolvin/watchfiles",
       "fork": "gounthar/watchfiles",
       "lang": "rust",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (8 wheels in 1.2.0); no local build needed"
     },
     {
       "name": "zstandard",
@@ -79,7 +82,8 @@
       "source": "tree-sitter/py-tree-sitter",
       "fork": "gounthar/py-tree-sitter",
       "lang": "c",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (5 wheels in 0.26.0); no local build needed"
     },
     {
       "name": "tree-sitter-bash",
@@ -107,7 +111,8 @@
       "source": "huggingface/safetensors",
       "fork": "gounthar/safetensors",
       "lang": "rust",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (1 wheel in 0.8.0); no local build needed"
     },
     {
       "name": "tiktoken",
@@ -125,7 +130,8 @@
       "source": "oconnor663/blake3-py",
       "fork": "gounthar/blake3-py",
       "lang": "rust+c",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (8 wheels in 1.0.9); no local build needed"
     },
     {
       "name": "pillow",
@@ -153,7 +159,8 @@
       "source": "pydantic/jiter",
       "fork": "gounthar/jiter",
       "lang": "rust",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (7 wheels in 0.16.0); no local build needed"
     },
     {
       "name": "fastar",
@@ -162,7 +169,8 @@
       "source": "DoctorJohn/fastar",
       "fork": "gounthar/fastar",
       "lang": "rust",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (11 wheels in 0.12.0); no local build needed"
     },
     {
       "name": "openai-harmony",
@@ -198,7 +206,8 @@
       "source": "zeromq/pyzmq",
       "fork": "gounthar/pyzmq",
       "lang": "c",
-      "status": "built"
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (1 wheel in 27.2.0); no local build needed"
     },
     {
       "name": "rignore",
@@ -206,8 +215,9 @@
       "source": "patrick91/rignore",
       "fork": "gounthar/rignore",
       "lang": "rust",
-      "status": "built",
-      "version": "0.8.1"
+      "status": "not-needed",
+      "version": "0.8.1",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (11 wheels in 0.8.1); no local build needed"
     },
     {
       "name": "uvloop",
@@ -294,8 +304,8 @@
       "source": "aio-libs/propcache",
       "fork": "gounthar/propcache",
       "lang": "c",
-      "status": "built",
-      "notes": "aiohttp/yarl transitive dep. Built on F3, in index."
+      "status": "not-needed",
+      "notes": "Upstream publishes riscv64 wheels on PyPI (14 wheels in 0.5.2); no local build needed"
     },
     {
       "name": "hf-xet",

--- a/scripts/detect-and-trigger.sh
+++ b/scripts/detect-and-trigger.sh
@@ -53,9 +53,9 @@ for i in $(seq 0 $((PACKAGE_COUNT - 1))); do
     fork=$(jq -r ".packages[$i].fork" "$PACKAGES_FILE")
     status=$(jq -r ".packages[$i].status" "$PACKAGES_FILE")
 
-    # Skip packages that aren't built yet
-    if [ "$status" = "pending" ]; then
-        printf "  %-20s  SKIPPED (status: pending)\n" "$name"
+    # Skip packages we don't build: not ready yet, or upstream ships them
+    if [ "$status" = "pending" ] || [ "$status" = "not-needed" ]; then
+        printf "  %-20s  SKIPPED (status: %s)\n" "$name" "$status"
         continue
     fi
 


### PR DESCRIPTION
Eleven packages we build on the F3 now ship riscv64 wheels on PyPI, so we are spending board time on wheels pip can already resolve upstream: pydantic-core, tokenizers, watchfiles, tree-sitter, safetensors, blake3, jiter, fastar, pyzmq, rignore, propcache.

I checked each against the PyPI JSON API for a wheel matching the cp313 build target, counting abi3 as covering cp313. All eleven are covered.

Marked `not-needed` rather than deleted, because `generate-index.py` reads the same `packages.json`. Deleting an entry drops it from the PEP 503 index and breaks anyone pinned to it for wheels we already published. The status stops the build and leaves the index serving.

That meant fixing the skip condition, which only tested `pending`. ijson has been `not-needed` since it was added and was still getting version-checked every run, so the status was not doing anything. Both values skip now.

Ran the skip loop against the new file: 20 build, 14 skip. I did not run `detect-and-trigger.sh` itself, since it calls `gh workflow run` against the forks and has no dry-run flag.

Two calls that are yours: whether the forks for these eleven are worth keeping, and whether the index entries should eventually retire too.

Refs #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package tracking to recognize components that do not require building because compatible riscv64 wheels are available upstream.
  * Improved package filtering to skip both pending and unnecessary builds.
  * Skip messages now display the package’s current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->